### PR TITLE
Significant performance gain through improved edge indexing

### DIFF
--- a/jLouvain.js
+++ b/jLouvain.js
@@ -17,6 +17,7 @@
 		var original_graph_edges;
 		var original_graph = {};
 		var partition_init;
+		var edge_index = {};
 
 		//Helpers
 		function make_set(array) {
@@ -79,15 +80,12 @@
 
 		function add_edge_to_graph(graph, edge) {
 			update_assoc_mat(graph, edge);
-
-			var edge_index = graph.edges.map(function (d) {
-				return d.source + '_' + d.target;
-			}).indexOf(edge.source + '_' + edge.target);
-
-			if (edge_index !== -1) {
-				graph.edges[edge_index].weight = edge.weight;
+			
+			if (edge_index[edge.source+'_'+edge.target]) {
+				graph.edges[edge_index[edge.source+'_'+edge.target]].weight = edge.weight;
 			} else {
 				graph.edges.push(edge);
+				edge_index[edge.source+'_'+edge.target] = graph.edges.length - 1;
 			}
 		}
 
@@ -298,6 +296,8 @@
 				var new_weight = (w_prec + weight);
 				add_edge_to_graph(ret, {'source': com1, 'target': com2, 'weight': new_weight});
 			});
+			
+			edge_index = {};
 
 			return ret;
 		}


### PR DESCRIPTION
First of all, thanks for porting the Louvain algorithm to Javascript! Great work. I've used it in various applications so far and found out that the overall computation times of the implementation could use some improvements, especially when trying to detect communities in larger networks (over 1000 nodes / 5000 edges).

Upon inspection of your code, I noticed that a new ``edge_index`` is created each time the ``add_edge_to_graph`` function is called. What's happening here is that each time an edge is added to an induced graph, the entire edges array needs to be iterated to find out whether or not the edge exists already. When working with a lot of edges, this quickly leads to a very severe performance drop.

Instead, it would be better to work with an ``edge_index`` in the form of an object to allow quick lookups of whether or not an edge exists already or not. Whenever a new edge is added to the graph, the index is updated as well. When adding edges to the induced graph is finished, the index is simply reset 

The performance gain here is very significant - I've tested this on a network of 20k nodes / 24k edges and saw computation times decrease from 101000ms to 1500ms (!!!). On a smaller network of 2500 nodes / 5000 edges, the improvement is not that staggering, but still significant - from 3000ms to 500ms.

This pull request implements the above logic - I hope it's of use to anyone.

