### PR TITLE
Use JSON.parse/stringify to clone an object

### DIFF
--- a/src/jLouvain.js
+++ b/src/jLouvain.js
@@ -115,14 +115,7 @@ function clone(obj) {
 	if (obj === null || typeof obj !== 'object') {
 		return obj;
 	}
-
-	let temp = obj.constructor();
-
-	for (let key in obj) {
-		temp[key] = clone(obj[key]);
-	}
-
-	return temp;
+	return JSON.parse(JSON.stringify(obj));
 }
 
 //Core-Algorithm Related


### PR DESCRIPTION
We noticed that the `clone()` function can cause an error if the `constructor` property is not a function.

This is a (rare?) case when a POJO has a property named `constructor`:

```json
{
   "building": "House A",
   "constructor": "Construction Company Ltd."
}
```

This PR replaces the main part of the `clone()` function with the `JSON.parse/stringify` combo.

